### PR TITLE
[WFCORE-1316] patch apply command not working as expected in

### DIFF
--- a/patching/src/main/java/org/jboss/as/patching/cli/PatchHandler.java
+++ b/patching/src/main/java/org/jboss/as/patching/cli/PatchHandler.java
@@ -316,6 +316,9 @@ public class PatchHandler extends CommandHandlerWithHelp {
     @Override
     protected void doHandle(CommandContext ctx) throws CommandLineException {
         final ParsedCommandLine parsedLine = ctx.getParsedCommandLine();
+        if(host.isPresent(parsedLine) && !ctx.isDomainMode()) {
+            throw new CommandFormatException("The --host option is not available in the current context. Connection to the controller might be unavailable or not running in domain mode.");
+        }
         final String action = this.action.getValue(parsedLine);
         if(INSPECT.equals(action)) {
             doInspect(ctx);


### PR DESCRIPTION
non-interactive mode in domain mode

It the host option is specified it shouldn't allow the command to be
executed unless the CLI is online and running in domain mode.